### PR TITLE
Ownership

### DIFF
--- a/contracts/bitcoin-colors.clar
+++ b/contracts/bitcoin-colors.clar
@@ -7,31 +7,35 @@
 (define-map token-count principal uint)
 (define-map market uint {price: uint, commission: principal})
 (define-map mint-address bool principal)
-
-;; Constants
-(define-constant CONTRACT-OWNER tx-sender)
-(define-constant MAX-SUPPLY u1000000)
-(define-constant WALLET 'SPNWZ5V2TPWGQGVDR6T7B6RQ4XMGZ4PXTEE0VQ0S)
-
-;; Errors
-(define-constant ERR-SOLD-OUT (err u300))
-(define-constant ERR-WRONG-COMMISSION (err u301))
-(define-constant ERR-NOT-AUTHORIZED (err u401))
-(define-constant ERR-NOT-FOUND (err u404))
-(define-constant ERR-LISTING (err u405))
-(define-constant ERR-MINT-FROZEN (err u406))
-(define-constant ERR-NO-OWNER (err u407))
+(define-map owners uint  {hash-bytes: (buff 32), version: (buff 1) } )
 
 ;; Variables
 (define-data-var last-id uint u0)
 (define-data-var contract-uri (string-ascii 80) "")
 (define-data-var base-uri (string-ascii 80) "")
+(define-data-var seeds uint {hashbytes: (buff 32), version: (buff 1)})
+(define-data-var escrow principal tx-sender)
 
-(define-public (claim (block { header: (buff 80), height: uint })
+;; Constants
+(define-constant CONTRACT-OWNER tx-sender)
+(define-constant MINT_PRICE 1000)
+
+;; Errors
+(define-constant ERR-FORBIDDEN (err u403))
+(define-constant ERR-NOT-FOUND (err u404))
+(define-constant ERR-LISTING (err u500))
+(define-constant ERR-NO-OWNER (err u502))
+
+(define-public (mint-btc (block { header: (buff 80), height: uint })
                       (proof { tx-index: uint, hashes: (list 12 (buff 32)), tree-depth: uint })
-                      (recipient principal))
-  (mint-many recipient (list recipient))
-)
+                      (mint-btc-tx {some-data: uint})
+                      (recipient-btc {hashbytes: (buff 32), version: (buff 1)}))
+    (begin
+        (asserts! (was-minted mint-btc-tx) err-invalid-btc-tx)
+        (asserts! (is-eq (get-recipient mint-btc-tx) recipient-btc) err-not-authorized)
+        (asserts! (is-eq (get-mint-price mint-btc-tx) MINT_PRICE) err-not-authorized)
+        (map-insert owners id recipient)
+        (mint-many (var-get escrow (list recipient-btc)))))
 
 (define-read-only (get-balance (account principal))
     (default-to u0
@@ -40,6 +44,13 @@
 ;; SIP009: Get the owner of the specified token ID
 (define-read-only (get-owner (id uint))
     (ok (nft-get-owner? bitcoin-colors id)))
+
+(define-public (get-owner-2 (id uint))
+  (let ((stx-owner (unwrap! (nft-get-owner? bitcoin-colors id) err-not-found)))
+    (if (is-eq (var-get escrow) stx-owner)
+        ;; if in escrow get real owner from map
+        (merge {chain: "btc", name: none} (map-get? owners id))
+        (merge {chain: "stx"} (principal-destruct? stx-owner)))))
 
 ;; SIP009: Get the last token ID
 (define-read-only (get-last-token-id)
@@ -102,35 +113,56 @@
     (ok true)))
 
 (define-public (set-base-uri (new-base-uri (string-ascii 80)))
-    (if (is-eq tx-sender CONTRACT-OWNER) 
+    (if (is-eq tx-sender CONTRACT-OWNER)
         (ok (var-set base-uri new-base-uri))
         ERR-NOT-AUTHORIZED))
 
 (define-public (set-contract-uri (new-contract-uri (string-ascii 80)))
-    (if (is-eq tx-sender CONTRACT-OWNER) 
+    (if (is-eq tx-sender CONTRACT-OWNER)
         (ok (var-set contract-uri new-contract-uri))
         ERR-NOT-AUTHORIZED))
 
-(define-private (mint-many (new-owner principal) (orders (list 50 principal)))
+(define-data-var ctx-new-owner principal tx-sender)
+
+(define-private (mint-many (new-owner principal)
+                           (orders (list 50 {hashbytes: (buff 32), version: (buff 1)})))
     (let
         (
             (next-nft-id (+ u1 (var-get last-id)))
-            (enabled (asserts! (< (var-get last-id) MAX-SUPPLY) ERR-SOLD-OUT))
-            (id-reached (fold mint-many-iter orders next-nft-id))
-            (payment (* u50000000 (- id-reached next-nft-id)))
             (current-balance (get-balance new-owner))
         )
-        (begin
+        (var-set ctx-new-owner new-owner)
+        (let ((id-reached (fold mint-many-iter orders next-nft-id)))
             (var-set last-id (- id-reached u1))
             (map-set token-count new-owner (+ current-balance (- id-reached next-nft-id)))
-            (try! (stx-transfer? payment new-owner WALLET))
-        )
-        (ok id-reached)))
+            (ok id-reached))))
 
 (define-private (mint-many-iter (new-owner principal) (next-id uint))
-    (if (or (is-eq MAX-SUPPLY u0) (<= next-id MAX-SUPPLY))
-        (begin
-            (unwrap! (nft-mint? bitcoin-colors next-id new-owner) next-id)
-            (+ next-id u1)
-        )
-        next-id))
+    (begin
+        ;; colors must be unique
+        (asserts! (map-insert seed (to-hash recipient-btc)) next-id)
+        (unwrap! (nft-mint? bitcoin-colors next-id (var-get ctx-new-owner)) next-id)
+        (+ next-id u1)
+    ))
+
+(define-public (transfer-btc-btc (id uint)
+                (sender {hashbytes: (buff 32), version: (buff 1)})
+                (recipient {hashbytes: (buff 32), version: (buff 1)})
+                (transfer-btc-tx {some-data: uint}))
+  (begin
+    (asserts! (was-minted transfer-btc-tx) err-invalid-btc-tx)
+    (asserts! (is-eq (get-sender transfer-btc-tx) sender) err-not-authorized)
+    (asserts! (is-eq (get-recipient transfer-btc-tx) recipient) err-not-authorized)
+    (asserts! (is-eq (get-id transfer-btc-tx) id) err-not-authorized)
+    ;; some asset transfers for post conditions
+    (try! (nft-transfer? bitcoin-colors id escrow-contract tx-sender))
+    (try! (nft-transfer? bitcoin-colors id tx-sender escrow-contract))
+    (map-set owners id recipient)))
+
+(define-public (transfer-stx-btc (id uint) (sender principal) (recipient {hashbytes: (buff 32), version: (buff 1)}))
+  ;; TODO
+)
+
+(define-public (transfer-btc-stx (id uint) (sender {hashbytes: (buff 32), version: (buff 1)}) (recipient principal) (transfer-btc-tx {some-data: unit}))
+  ;; TODO
+)


### PR DESCRIPTION
From the information available, I tried to build a clarity contract to better understand the features.

I like the idea of an escrow contract that holds nfts if they are owned by btc addresses (like a bridge). Therefore, I added get-owner-2 that returns `(response {hashbytes: (buff 32), name: (optional (ascii 40), version: (buf 1)})`

Changing the escrow contract in a version 2 might be complicated to keep track ownership

