### PR TITLE
Add deterministic bits & exclusions

### DIFF
--- a/generation/generate_traits.py
+++ b/generation/generate_traits.py
@@ -26,12 +26,14 @@ class TraitGenerator():
   which specifies the trait types and values that we expect to generate.
 
   This should be an object which looks like, for example:
-  [ { "trait_type": "Eyes", "value": "Laser Eyes", "weight": 0.01 },
-    { "trait_type": "Eyes", "value": "Normal Eyes", "weight": 0.79 },
-    { "trait_type": "Eyes", "value": "Glasses", "weight": 0.20 },
-    { "trait_type": "Shirt Color", "value": "Red", "weight": 0.30 },
-    { "trait_type": "Shirt Color", "value": "Green", "weight": 0.40 },
-    { "trait_type": "Shirt Color", "value": "Blue", "weight": 0.30 } ]
+  { "specification":
+    [ { "trait_type": "Eyes", "value": "Laser Eyes", "weight": 0.01 },
+      { "trait_type": "Eyes", "value": "Normal Eyes", "weight": 0.79 },
+      { "trait_type": "Eyes", "value": "Glasses", "weight": 0.20 },
+      { "trait_type": "Shirt Color", "value": "Red", "weight": 0.30 },
+      { "trait_type": "Shirt Color", "value": "Green", "weight": 0.40 },
+      { "trait_type": "Shirt Color", "value": "Blue", "weight": 0.30 } ]
+  }
 
   The final output of the generation, for a single address, will be something like: 
   [ { "trait_type": "Eyes", "value": "Laser Eyes" },
@@ -40,9 +42,23 @@ class TraitGenerator():
   Lower weights will be generated less frequently, in proportion to their value relative to
   the other weights in the same trait_type. For example, laser eyes is expected to appear in 
   1% of the samples, and a red shirt color in 30% of the samples.
+
+  You can also add exclusions to the traits, to prevent one trait from being added to another.
+  Note this WILL affect the distributions of the outputs and may cause them to be shifted from
+  the intended specification.
+    { "trait_type": "Eyes", "value": "Glasses", "weight": 0.20,
+      "exclusions": { "trait_type": "Q2 Background", "value": "Orange" } },
+
+  If you want to be explicit about how many characters correspond to which traits, these can be
+  explicitly specified in the definition.
+    { "character_allocation": { "Q1 Background": 4, "Q2 Background": 4,
+                                "Q3 Background": 4, "Q4 Background": 4 },
+    "specification": [ ... ] }
   '''
   def __init__(self, trait_specification, verbose=True):
-    self.trait_specification = pd.DataFrame(trait_specification)
+    self.trait_specification = pd.DataFrame(trait_specification['specification'])
+    
+    self.character_allocation = trait_specification.get('character_allocation') 
     self.verbose = verbose
 
   '''
@@ -66,24 +82,40 @@ class TraitGenerator():
     traits = sorted(df['trait_type'].unique())
 
     # naively spilt the string length by the number of traits 
-    chunk_length = len(addr) // len(traits)
+    if self.character_allocation:
+      chunk_lengths = []
+      for trait in traits:
+        chunk_lengths.append(self.character_allocation[trait])
+    else:
+      chunk_lengths = [len(addr) // len(traits) for _ in range(len(traits))]
+
+    if sum(chunk_lengths) > len(raw_addr):
+      raise ValueError(f'Input string is too short; needs at least {sum(chunk_lengths)} characters')
 
     # convert string into array of "probabilities"
     ps = []
-    for i, trait in enumerate(traits):
-      ss = addr[i * chunk_length : (i + 1) * chunk_length]
+    curr = 0
+    for trait, chunk_size in zip(traits, chunk_lengths):
+      ss = addr[curr : curr + chunk_size]
       p = self.get_probability(ss)
       if p is None: 
         return
       if self.verbose:
         print(f'Substring {i}: {ss.hex()} - {p}')
+      curr += chunk_size
       ps.append(p)
 
     result = []
+    exclusions = []
     for i, trait in enumerate(traits):
       if self.verbose:
         print(f'\nWorking on trait: {trait}')
       matching = df[df['trait_type'] == trait].sort_values(by='value')
+
+      # Remove exclusions
+      relevant_exclusions = set([d['value'] for d in exclusions if d['trait_type'] == trait])
+      matching = matching[~matching['value'].isin(relevant_exclusions)]
+
       matching['normalized'] = matching['weight'] / matching['weight'].sum()
       rolling_sum = 0.0
       for j, row in matching.iterrows():
@@ -95,6 +127,8 @@ class TraitGenerator():
             'trait_type': row.trait_type,
             'value': row.value
           })
+          if type(row.exclusions) is list:
+            exclusions += row.exclusions
           break
     return result
 

--- a/generation/generate_traits.py
+++ b/generation/generate_traits.py
@@ -57,9 +57,22 @@ class TraitGenerator():
   '''
   def __init__(self, trait_specification, verbose=True):
     self.trait_specification = pd.DataFrame(trait_specification['specification'])
+    self.preprocess_exclusions()
     
     self.character_allocation = trait_specification.get('character_allocation') 
     self.verbose = verbose
+
+  def preprocess_exclusions(self):
+    for i, s in self.trait_specification.iterrows():
+      reverse = { 'trait_type': s['trait_type'], 'value': s['value'] }
+      if type(s['exclusions']) is list:
+        for e in s['exclusions']:
+          for j, t in self.trait_specification.iterrows():
+            if (e['trait_type'] == t['trait_type'] and e['value'] == t['value']):
+              if type(t['exclusions']) is not list:
+                self.trait_specification.at[j, 'exclusions'] = [reverse]
+              elif reverse not in t['exclusions']:
+                self.traits_specification.at[j, 'exclusions'] = self.trait_specification.at[j, 'exclusions'] + [reverse]
 
   '''
   generate_traits(addr)

--- a/generation/trait_specification.json
+++ b/generation/trait_specification.json
@@ -1,602 +1,624 @@
-[
-  {
-    "trait_type": "Q1 Background",
-    "value": "Orange",
-    "weight": 0.13
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Red",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Maroon",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Yellow",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Olive",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Lime",
-    "weight": 0.11
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Green",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Aqua",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Teal",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Blue",
-    "weight": 0.07
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Navy",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Fuchsia",
-    "weight": 0.05
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Purple",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Silver",
-    "weight": 0.14
-  },
-  {
-    "trait_type": "Q1 Background",
-    "value": "Gray",
-    "weight": 0.1
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Orange",
-    "weight": 0.13
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Red",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Maroon",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Yellow",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Olive",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Lime",
-    "weight": 0.11
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Green",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Aqua",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Teal",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Blue",
-    "weight": 0.07
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Navy",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Fuchsia",
-    "weight": 0.05
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Purple",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Silver",
-    "weight": 0.14
-  },
-  {
-    "trait_type": "Q1 Foreground",
-    "value": "Gray",
-    "weight": 0.1
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Orange",
-    "weight": 0.13
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Red",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Maroon",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Yellow",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Olive",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Lime",
-    "weight": 0.11
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Green",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Aqua",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Teal",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Blue",
-    "weight": 0.07
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Navy",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Fuchsia",
-    "weight": 0.05
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Purple",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Silver",
-    "weight": 0.14
-  },
-  {
-    "trait_type": "Q2 Background",
-    "value": "Gray",
-    "weight": 0.1
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Orange",
-    "weight": 0.13
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Red",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Maroon",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Yellow",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Olive",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Lime",
-    "weight": 0.11
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Green",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Aqua",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Teal",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Blue",
-    "weight": 0.07
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Navy",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Fuchsia",
-    "weight": 0.05
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Purple",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Silver",
-    "weight": 0.14
-  },
-  {
-    "trait_type": "Q2 Foreground",
-    "value": "Gray",
-    "weight": 0.1
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Orange",
-    "weight": 0.13
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Red",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Maroon",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Yellow",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Olive",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Lime",
-    "weight": 0.11
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Green",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Aqua",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Teal",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Blue",
-    "weight": 0.07
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Navy",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Fuchsia",
-    "weight": 0.05
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Purple",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Silver",
-    "weight": 0.14
-  },
-  {
-    "trait_type": "Q3 Background",
-    "value": "Gray",
-    "weight": 0.1
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Orange",
-    "weight": 0.13
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Red",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Maroon",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Yellow",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Olive",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Lime",
-    "weight": 0.11
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Green",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Aqua",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Teal",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Blue",
-    "weight": 0.07
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Navy",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Fuchsia",
-    "weight": 0.05
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Purple",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Silver",
-    "weight": 0.14
-  },
-  {
-    "trait_type": "Q3 Foreground",
-    "value": "Gray",
-    "weight": 0.1
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Orange",
-    "weight": 0.13
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Red",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Maroon",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Yellow",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Olive",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Lime",
-    "weight": 0.11
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Green",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Aqua",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Teal",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Blue",
-    "weight": 0.07
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Navy",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Fuchsia",
-    "weight": 0.05
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Purple",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Silver",
-    "weight": 0.14
-  },
-  {
-    "trait_type": "Q4 Background",
-    "value": "Gray",
-    "weight": 0.1
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Orange",
-    "weight": 0.13
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Red",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Maroon",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Yellow",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Olive",
-    "weight": 0.01
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Lime",
-    "weight": 0.11
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Green",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Aqua",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Teal",
-    "weight": 0.03
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Blue",
-    "weight": 0.07
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Navy",
-    "weight": 0.12
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Fuchsia",
-    "weight": 0.05
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Purple",
-    "weight": 0.02
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Silver",
-    "weight": 0.14
-  },
-  {
-    "trait_type": "Q4 Foreground",
-    "value": "Gray",
-    "weight": 0.1
-  }
-]
+{
+  "character_allocation": {
+    "Q1 Background": 3,
+    "Q2 Background": 3,
+    "Q3 Background": 3,
+    "Q4 Background": 3,
+    "Q1 Foreground": 3,
+    "Q2 Foreground": 3,
+    "Q3 Foreground": 3,
+    "Q4 Foreground": 3
+  },
+  "specification": [
+    {
+      "trait_type": "Q1 Background",
+      "value": "Orange",
+      "weight": 0.13,
+      "exclusions": [
+        {
+          "trait_type": "Q2 Background",
+          "value": "Orange"
+        },
+        {
+          "trait_type": "Q2 Background",
+          "value": "Red"
+        }
+      ]
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Red",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Maroon",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Yellow",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Olive",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Lime",
+      "weight": 0.11
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Green",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Aqua",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Teal",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Blue",
+      "weight": 0.07
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Navy",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Fuchsia",
+      "weight": 0.05
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Purple",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Silver",
+      "weight": 0.14
+    },
+    {
+      "trait_type": "Q1 Background",
+      "value": "Gray",
+      "weight": 0.1
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Orange",
+      "weight": 0.13
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Red",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Maroon",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Yellow",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Olive",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Lime",
+      "weight": 0.11
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Green",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Aqua",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Teal",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Blue",
+      "weight": 0.07
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Navy",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Fuchsia",
+      "weight": 0.05
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Purple",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Silver",
+      "weight": 0.14
+    },
+    {
+      "trait_type": "Q1 Foreground",
+      "value": "Gray",
+      "weight": 0.1
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Orange",
+      "weight": 0.13
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Red",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Maroon",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Yellow",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Olive",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Lime",
+      "weight": 0.11
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Green",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Aqua",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Teal",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Blue",
+      "weight": 0.07
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Navy",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Fuchsia",
+      "weight": 0.05
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Purple",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Silver",
+      "weight": 0.14
+    },
+    {
+      "trait_type": "Q2 Background",
+      "value": "Gray",
+      "weight": 0.1
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Orange",
+      "weight": 0.13
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Red",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Maroon",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Yellow",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Olive",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Lime",
+      "weight": 0.11
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Green",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Aqua",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Teal",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Blue",
+      "weight": 0.07
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Navy",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Fuchsia",
+      "weight": 0.05
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Purple",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Silver",
+      "weight": 0.14
+    },
+    {
+      "trait_type": "Q2 Foreground",
+      "value": "Gray",
+      "weight": 0.1
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Orange",
+      "weight": 0.13
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Red",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Maroon",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Yellow",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Olive",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Lime",
+      "weight": 0.11
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Green",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Aqua",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Teal",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Blue",
+      "weight": 0.07
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Navy",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Fuchsia",
+      "weight": 0.05
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Purple",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Silver",
+      "weight": 0.14
+    },
+    {
+      "trait_type": "Q3 Background",
+      "value": "Gray",
+      "weight": 0.1
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Orange",
+      "weight": 0.13
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Red",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Maroon",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Yellow",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Olive",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Lime",
+      "weight": 0.11
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Green",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Aqua",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Teal",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Blue",
+      "weight": 0.07
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Navy",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Fuchsia",
+      "weight": 0.05
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Purple",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Silver",
+      "weight": 0.14
+    },
+    {
+      "trait_type": "Q3 Foreground",
+      "value": "Gray",
+      "weight": 0.1
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Orange",
+      "weight": 0.13
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Red",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Maroon",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Yellow",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Olive",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Lime",
+      "weight": 0.11
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Green",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Aqua",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Teal",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Blue",
+      "weight": 0.07
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Navy",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Fuchsia",
+      "weight": 0.05
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Purple",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Silver",
+      "weight": 0.14
+    },
+    {
+      "trait_type": "Q4 Background",
+      "value": "Gray",
+      "weight": 0.1
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Orange",
+      "weight": 0.13
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Red",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Maroon",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Yellow",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Olive",
+      "weight": 0.01
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Lime",
+      "weight": 0.11
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Green",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Aqua",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Teal",
+      "weight": 0.03
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Blue",
+      "weight": 0.07
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Navy",
+      "weight": 0.12
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Fuchsia",
+      "weight": 0.05
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Purple",
+      "weight": 0.02
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Silver",
+      "weight": 0.14
+    },
+    {
+      "trait_type": "Q4 Foreground",
+      "value": "Gray",
+      "weight": 0.1
+    }
+  ]
+}


### PR DESCRIPTION
- Add the (optional) ability to specify how many characters should be allocated to each trait
- Add the (optional) ability to specify which other traits should be excluded, if one is chosen

The second one has a few caveats which may impact the way trait generation happens and the way traits are distributed.

Let's say we have two `trait_type`s, "Foreground" and "Background", with three possible values each, Red (R), Blue (B), Green (G). There are therefore 3 × 3 possible combinations: {RR, RB, RG, BR, BB, BG, GR, GB, GG}. Let's say for both, R has a weight of 0.5, B 0.25, and G 0.25. We can imagine a binary encoding of 2 bits for each, such that:

- Foreground: 00: Red, 01: Red, 10: Blue, 11: Green
- Background: 00: Red, 01: Red, 10: Blue, 11: Green

So that a string 0110, for example would correspond to a Red (01) foreground and a Blue (10) background.

However, if we create an exclusion for "Foreground: Red, Background: Red", then the strings:
0000, 0001, 0100, 0101 become invalid, since Red cannot match with Red, and all those strings specify that combination.

The way we deal with this naively is to keep the first trait, and _redistribute_ the probabilities for the rest across the non-colliding traits. So if we hit Red on the foreground, then the probabilities for the next trait would become Blue: 0.5, Green: 0.5, and could be distributed like so:
- Blue: 00, 01
- Green: 10, 11

And so the string 0000 (previously invalid) now becomes Foreground: Red, Background: Blue, instead of Foreground: Red, Background: Red.

Unfortunately, this has a few negative consequences:
- You can no longer tell from a substring in isolation what its value is, since it depends on the traits before it; "00" could mean something different, even if in the same position, in different strings.
- Probabilities will get moved around a little; in this case, with this implementation, the Background Red will *not* appear in 50% of the cases, but rather we expect it to appear in 25% of the cases. The foreground remains the same at 50%, since this implementation is asymmetric.

There are probably better algorithms for this, but we can see how this does and whether any re-evaluation is required.